### PR TITLE
Step base dependency down to 4.7

### DIFF
--- a/modalagents.cabal
+++ b/modalagents.cabal
@@ -19,7 +19,7 @@ executable modalcombat
     parsec >= 3.1.7,
     text >= 1.1,
     transformers >= 0.4.1,
-    base >=4.8
+    base >=4.7
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -34,6 +34,6 @@ executable modalagents
     parsec >= 3.1.7,
     text >= 1.1,
     transformers >= 0.4.1,
-    base >=4.8
+    base >=4.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
The binary distribution of GHC for MacOS includes base 4.7, so allow that here.
