### PR TITLE
Make I/O work on Windows

### DIFF
--- a/modalagents.cabal
+++ b/modalagents.cabal
@@ -9,15 +9,16 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 executable modalcombat
-  extensions:          OverloadedStrings
   main-is:             ModalCombat.hs
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
   build-depends:
+    base >= 4.7,
+    bytestring >= 0.10,
     containers >= 0.5,
     mtl >= 2.2.1,
     optparse-applicative >=0.10,
     parsec >= 3.1.7,
     text >= 1.1,
-    transformers >= 0.4.1,
-    base >=4.7
-  hs-source-dirs:      src
-  default-language:    Haskell2010
+    transformers >= 0.4.1

--- a/src/Modal/Code.hs
+++ b/src/Modal/Code.hs
@@ -207,22 +207,22 @@ codeFragmentParser conf = try indent *> pFrag where
   pForO = pFor OutcomeT outcome outcomes
   pFor t x xs = For t
     <$> (keyword "for" *> keyword x *> varname)
-    <*> (keyword "in" *> rangeParser xs parser <* w <* newline)
+    <*> (keyword "in" *> rangeParser xs parser <* w <* endOfLine)
     <*> pBlock
   pForN = ForN
     <$> (keyword "for" *> keyword "number" *> varname)
-    <*> (keyword "in" *> boundedRange <* w <* newline)
+    <*> (keyword "in" *> boundedRange <* w <* endOfLine)
     <*> pBlock
   pLetN = LetN
     <$> (keyword "let" *> varname <* symbol "=")
     <*> parser <* eols
   pIf = If
-    <$> (keyword "if" *> parser <* w <* newline)
+    <$> (keyword "if" *> parser <* w <* endOfLine)
     <*> pBlock
   pIfElse = IfElse
-    <$> (keyword "if" *> parser <* w <* newline)
+    <$> (keyword "if" *> parser <* w <* endOfLine)
     <*> pBlock
-    <*> (indent *> keyword "else" *> w *> newline *> pBlock)
+    <*> (indent *> keyword "else" *> w *> endOfLine *> pBlock)
   pBlock = many1 $ try $ codeFragmentParser conf{indentLevel=succ $ indentLevel conf}
   pPass = symbol "pass" $> Pass <* w <* eol
   pReturn = try returnThing <|> returnNothing <?> "a return statement"
@@ -349,7 +349,7 @@ _testCodeParser = testAllSamples where
 
 codeMapParser :: Parser Code
 codeMapParser = ActionMap . Map.fromList <$> many1 assignment where
-  indent = (many (w *> newline)) *> char '\t'
+  indent = (many (w *> endOfLine)) *> char '\t'
   iffParsers = [symbol "↔", symbol "<->", keyword "iff"]
   pIff = void $ choice $ map try iffParsers
   assignment = (,) <$> (indent *> parser <* pIff) <*> (parser <* eols)

--- a/src/Modal/Combat.hs
+++ b/src/Modal/Combat.hs
@@ -478,11 +478,11 @@ gameParser = many P.ignoredLine *> (parser `sepEndBy` many P.ignoredLine) <* end
 
 -------------------------------------------------------------------------------
 
-parseFile :: FilePath -> IO [GameObject]
-parseFile path = runFile (parse gameParser path) path
+parseFile :: Bool -> FilePath -> IO [GameObject]
+parseFile useUtf8 path = runFile (parse gameParser path) useUtf8 path
 
-compileFile :: FilePath -> IO Setting
-compileFile path = run . gameToSetting path =<< parseFile path
+compileFile :: Bool -> FilePath -> IO Setting
+compileFile useUtf8 path = run . gameToSetting path =<< parseFile useUtf8 path
 
 playGame :: Name -> [GameObject] -> IO ()
 playGame name game = do
@@ -493,8 +493,8 @@ playGame name game = do
   putStrLn ""
   mapM_ (executeAction setting) (actions game)
 
-playFile :: FilePath -> IO ()
-playFile path = parseFile path >>= playGame path
+playFile :: Bool ->  FilePath -> IO ()
+playFile useUtf8 path = parseFile useUtf8 path >>= playGame path
 
 playGame' :: Name -> Setting -> [GameObject] -> IO ()
 playGame' name base game = do
@@ -508,5 +508,5 @@ playGame' name base game = do
   putStrLn ""
   mapM_ (executeAction setting) (actions game)
 
-playFile' :: FilePath -> Setting -> IO ()
-playFile' path setting = parseFile path >>= playGame' path setting
+playFile' :: Bool -> FilePath -> Setting -> IO ()
+playFile' useUtf8 path setting = parseFile useUtf8 path >>= playGame' path setting

--- a/src/Modal/Parser.hs
+++ b/src/Modal/Parser.hs
@@ -40,10 +40,10 @@ symbol :: String -> Parser ()
 symbol s = void $ w *> string s <* w
 
 eol :: Parser ()
-eol = try (void newline) <|> try eof <?> "a line ending"
+eol = try (void endOfLine) <|> try eof <?> "a line ending"
 
 eols :: Parser ()
-eols = void $ many1 (w *> newline)
+eols = void $ many1 (w *> endOfLine)
 
 ignoredToken :: Parser ()
 ignoredToken
@@ -63,7 +63,7 @@ _lineComment :: Parser ()
 _lineComment = void ((string "--" *> many (noneOf "\n")) <?> "a line comment")
 
 ignoredLine :: Parser ()
-ignoredLine = many (void (char '\t') <|> ignoredToken) *> void newline
+ignoredLine = many (void (char '\t') <|> ignoredToken) *> void endOfLine
 
 w :: Parser ()
 w = void $ many ignoredToken
@@ -82,7 +82,7 @@ comma = symbol ","
 
 powerComma :: Parser () -- can span newlines and eat tabs etc. Ugh.
 powerComma = void $ wN *> string "," <* wN where
-  wN = void $ many (ignoredToken <|> void (char '\t') <|> void newline)
+  wN = void $ many (ignoredToken <|> void (char '\t') <|> void endOfLine)
 
 brackets :: Parser a -> Parser a
 brackets = between (symbol "[") (symbol "]")

--- a/src/Modal/Utilities.hs
+++ b/src/Modal/Utilities.hs
@@ -18,7 +18,9 @@ module Modal.Utilities
   ) where
 import Prelude hiding (readFile)
 import Control.Monad.Except hiding (mapM, sequence)
+import qualified Data.ByteString as BS
 import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (readFile)
 import System.IO (stderr, hPutStrLn)
 import System.Exit hiding (die)
@@ -75,5 +77,10 @@ force = either (error . printf "Forcing failed: %s" . show) id
 run :: Show x => Either x a -> IO a
 run = either die return
 
-runFile :: Show x => (Text -> Either x a) -> FilePath -> IO a
-runFile f path = run . f =<< readFile path
+readFileEnc :: Bool -> FilePath -> IO Text
+readFileEnc useUtf8 = if useUtf8 then readFileUtf8 else readFile
+  where
+    readFileUtf8 fn = decodeUtf8 <$> BS.readFile fn
+
+runFile :: Show x => (Text -> Either x a) -> Bool -> FilePath -> IO a
+runFile f useUtf8 path = run . f =<< readFileEnc useUtf8 path


### PR DESCRIPTION
Unicode handling in Windows is weird. Also, line endings. Grrr.

Output to terminal is still broken, you need to run `chcp 65001` to make it accept unicode. And a console font with all the characters.
